### PR TITLE
Add Japanese parenthesis to parenthesis ignore list

### DIFF
--- a/app/js/flashcard.js
+++ b/app/js/flashcard.js
@@ -465,7 +465,7 @@ function typedCorrect(userAnswer, answer) {
     let toBeAdded = [];
 
     if (settings.ignoreParenthesis) {
-        const re = /\([^)]*\) */g; //removes parenthesis and text btw them
+        const re = /[()（）][^()（）]*[()（）] */g; //removes parenthesis and text btw them
         for (x = 0; x < answers.length; x++) {
             const val = answers[x].replace(re, "").trim();
             if (!answers.includes(val)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "flashbang",
-	"version": "1.2.0",
+	"version": "1.21.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "flashbang",
-			"version": "1.2.0",
+			"version": "1.21.1",
 			"license": "ISC",
 			"dependencies": {
 				"electron-fetch": "^1.7.4",


### PR DESCRIPTION
Add Japanese-style (and potentially used in other languages too) unicode parentheses to the parenthesis-ignore list.

Another option was to use `xregexp` but I didn't want to add a new dependency.

Tested locally.